### PR TITLE
Fix pde.dt not being set // not accurately used in model decoder

### DIFF
--- a/experiments/train.py
+++ b/experiments/train.py
@@ -168,6 +168,7 @@ def main(args: argparse):
     pde.tmin = train_dataset.tmin
     pde.tmax = train_dataset.tmax
     pde.grid_size = base_resolution
+    pde.dt = train_dataset.dt
 
     dateTimeObj = datetime.now()
     timestring = f'{dateTimeObj.date().month}{dateTimeObj.date().day}{dateTimeObj.time().hour}{dateTimeObj.time().minute}'


### PR DESCRIPTION
As discussed in https://github.com/brandstetter-johannes/MP-Neural-PDE-Solvers/issues/6